### PR TITLE
Fix omniauth error page absence

### DIFF
--- a/app/views/sessions/failure.html.slim
+++ b/app/views/sessions/failure.html.slim
@@ -1,0 +1,6 @@
+.uk-container.uk-container-center
+  .uk-grid
+    .uk-width-2-3
+      .summary-list-item.uk-panel.uk-panel-box.uk-margin-top
+        p.uk-text-center.uk-text-large
+          | 認証エラーが発生しました


### PR DESCRIPTION
When clicking `cancel` at the Slack OAuth confirmation page, togelack returns 500 error due to view template absence.