### PR TITLE
Add simple search function

### DIFF
--- a/app/controllers/summaries_controller.rb
+++ b/app/controllers/summaries_controller.rb
@@ -7,12 +7,14 @@ class SummariesController < ApplicationController
   def index
     page = (params[:page] || 1).to_i
     source = Summary.newest.page(page)
+
     @summaries = SummaryDecorator.decorate_collection(source)
   end
 
   def list
     page = (params[:page] || 1).to_i
     source = Summary.newest.page(page).per(25)
+    source = source.match_text(params[:keyword]) if params[:keyword]
     @summaries = SummaryDecorator.decorate_collection(source)
   end
 

--- a/app/controllers/summaries_controller.rb
+++ b/app/controllers/summaries_controller.rb
@@ -7,7 +7,6 @@ class SummariesController < ApplicationController
   def index
     page = (params[:page] || 1).to_i
     source = Summary.newest.page(page)
-
     @summaries = SummaryDecorator.decorate_collection(source)
   end
 

--- a/app/models/summary.rb
+++ b/app/models/summary.rb
@@ -22,4 +22,12 @@ class Summary
       ms.select { |n| n.id == id }.first
     end
   end
+
+  def self.match_text (text)
+    message_ids = Message.any_of({ :text => /.*#{text}.*/ }).only(:_id).map do |v|
+      {message_ids: v}
+    end
+
+    any_of({ :title => /.*#{text}.*/ }, message_ids)
+  end
 end

--- a/app/views/summaries/_sidebar.html.slim
+++ b/app/views/summaries/_sidebar.html.slim
@@ -7,6 +7,15 @@
       ログインするとまとめを作成できます。
 
 .uk-panel.uk-panel-box.uk-margin-top
+  form.uk-form.uk-grid action='/summaries/list' v-on='submit: onSearch($event, search, loadMessages)'
+    .uk-width-3-4
+      input.uk-width-1-1 type='text' name='keyword' placeholder='検索' v-model='search' v-attr='readonly: nowLoading'
+    .uk-width-1-4
+      button.uk-button.uk-width-1-1 type='submit' v-attr='disabled: nowLoading'
+        i.fa.fa-eyedropper v-if='!nowLoading'
+        - # i.fa.fa-spinner.fa-spin v-if='nowLoading'
+
+.uk-panel.uk-panel-box.uk-margin-top
   .uk-panel-title
     a href=list_summaries_path
       | 最近作成されたまとめ


### PR DESCRIPTION
This PR is remake of #5.

Add simple search function to Togelack.
Now we can pass parameter `keyword` to `/list` and narrow down the Summaries.
`keyword` works for both titles and messages.