### PR TITLE
Add check user when update summary

### DIFF
--- a/app/controllers/summaries_controller.rb
+++ b/app/controllers/summaries_controller.rb
@@ -43,6 +43,7 @@ class SummariesController < ApplicationController
   end
 
   def update
+    raise 'permission error' unless @summary.user == @current_user
     if @summary.update(summary_params)
       render json: {result: @summary.decorate}, root: nil
     else


### PR DESCRIPTION
On the UI, only the owner of the summary can open it to the editor with button, but anyone can edit it by opening the editor directly.